### PR TITLE
Enemy now inflicts damage on Player via the CharacterColliderService.

### DIFF
--- a/Assets/KOTF/Core/Gameplay/Character/CharacterBase.cs
+++ b/Assets/KOTF/Core/Gameplay/Character/CharacterBase.cs
@@ -23,21 +23,26 @@ namespace KOTF.Core.Gameplay.Character
         #endregion
 
         #region Objected references
+        private Weapon _wieldedWeapon;
         protected ServiceProvider ServiceProvider { get; private set; }
         protected AnimationService AnimationService { get; private set; }
+        protected CharacterColliderService CharacterColliderService { get; private set; }
         protected Animator Animator { get; private set; }
-        public Weapon WieldedWeapon { get; set; }
         #endregion
 
         protected virtual void Awake()
         {
             ServiceProvider = ServiceProvider.GetInstance();
             AnimationService = ServiceProvider.Get<AnimationService>();
+            CharacterColliderService = ServiceProvider.Get<CharacterColliderService>();
         }
 
         protected virtual void Start()
         {
             Animator = GetComponent<Animator>();
+
+            _wieldedWeapon = GetComponentInChildren<Weapon>();
+            _wieldedWeapon.Owner = this;
         }
 
         protected virtual void Update()
@@ -56,19 +61,19 @@ namespace KOTF.Core.Gameplay.Character
 
         public virtual void Die()
         {
-            Debug.Log($"{gameObject.name} has died.");
+            Debug.Log($"{name} has died.");
             Destroy(gameObject);
         }
 
         public virtual void OnEnterAttackWindow()
         {
-
+            _wieldedWeapon.Collider.enabled = true;
         }
 
         public virtual void OnExitAttackWindow()
         {
-
+            _wieldedWeapon.Collider.enabled = false;
+            CharacterColliderService.Reset();
         }
-
     }
 }

--- a/Assets/KOTF/Core/Gameplay/Character/MainPlayerCharacter.cs
+++ b/Assets/KOTF/Core/Gameplay/Character/MainPlayerCharacter.cs
@@ -21,7 +21,6 @@ namespace KOTF.Core.Gameplay.Character
         private CharacterController _characterController;
 
         private EquipmentService _equipmentService;
-        private CharacterColliderService _characterColliderService;
 
         protected override void Awake()
         {
@@ -34,7 +33,6 @@ namespace KOTF.Core.Gameplay.Character
                 Debug.LogError($"{_movementInput} is null which is not permitted!");
 
             _equipmentService = ServiceProvider.Get<EquipmentService>();
-            _characterColliderService = ServiceProvider.Get<CharacterColliderService>();
 
             _equipmentService.AttachEquipmentTo<Weapon>(WeaponPrefabNames.LONGSWORD, gameObject);
         }
@@ -68,22 +66,6 @@ namespace KOTF.Core.Gameplay.Character
         public override void Attack()
         {
             TriggerAttackAnimation(Convert.ToBoolean(_attackInput.Input.ReadValue<float>()));
-        }
-
-        public override void Die()
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void OnEnterAttackWindow()
-        {
-            WieldedWeapon.Collider.enabled = true;
-        }
-
-        public override void OnExitAttackWindow()
-        {
-            WieldedWeapon.Collider.enabled = false;
-            _characterColliderService.Reset();
         }
     }
 }

--- a/Assets/KOTF/Core/Services/CharacterColliderService.cs
+++ b/Assets/KOTF/Core/Services/CharacterColliderService.cs
@@ -18,7 +18,7 @@ namespace KOTF.Core.Services
             _registeredCollisionIds.Add(victimId);
 
             victim.HealthPoints -= aggressorWeapon.BaseDamage;
-            Debug.Log($"Hit {victim.gameObject.name}");
+            Debug.Log($"{aggressorWeapon.Owner.name} inflicted {aggressorWeapon.BaseDamage} base damage upon {victim.gameObject.name}.");
             if (victim.HealthPoints <= 0)
                 victim.Die();
         }

--- a/Assets/KOTF/Core/Services/EquipmentService.cs
+++ b/Assets/KOTF/Core/Services/EquipmentService.cs
@@ -61,8 +61,6 @@ namespace KOTF.Core.Services
             if (attachmentGameObject is not Weapon weapon || !host.TryGetComponent(out CharacterBase hostCharacter))
                 return;
 
-            hostCharacter.WieldedWeapon = weapon;
-            weapon.Owner = hostCharacter;
             weapon.name = key;
         }
     }

--- a/Assets/KOTF/Core/Wrappers/KOTFGameObject.cs
+++ b/Assets/KOTF/Core/Wrappers/KOTFGameObject.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace KOTF.Core.Wrappers
@@ -7,9 +8,18 @@ namespace KOTF.Core.Wrappers
     {
         public new T GetComponent<T>()
         {
-            T component = base.GetComponent<T>();
+            return ValidateComponent(base.GetComponent<T>());
+        }
+
+        public new T GetComponentInChildren<T>()
+        {
+            return ValidateComponent(base.GetComponentInChildren<T>());
+        }
+
+        private T ValidateComponent<T>(T component)
+        {
             if (component == null)
-                Debug.LogError($"Could not get {nameof(T)} from {name}.");
+                throw new ArgumentException($"Could not get {typeof(T).Name} from {name}.");
 
             return component;
         }
@@ -19,7 +29,7 @@ namespace KOTF.Core.Wrappers
         {
             T @object = Object.FindObjectOfType<T>();
             if (@object == null)
-                Debug.LogError($"Couldn't find object of type {nameof(T)} requested by {name}.");
+                throw new ArgumentException($"Couldn't find object of type {typeof(T).Name} requested by {name}.");
 
             return @object;
         }

--- a/Assets/Resources/Prefabs/Weapons/Longsword.prefab
+++ b/Assets/Resources/Prefabs/Weapons/Longsword.prefab
@@ -95,7 +95,7 @@ BoxCollider:
   m_GameObject: {fileID: 5655345345969914227}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Size: {x: 0.04, y: 0.980288, z: 0.020938}
   m_Center: {x: 0, y: 0.282687, z: 0}


### PR DESCRIPTION
WieldedWeapon is now initialized on CharacterBase.Start by searching for the Weapon component on children. This works for the MainPlayerCharacter as well because the Equipment attachment is done at Awake, so the initialization from EquipmentService has been removed for now as it is redundant, but will probably be readded in the future whenever we implement weapon switching.