### PR TITLE
#77: Lowering an Attribute's value while having a Threshold defined r…

### DIFF
--- a/Assets/KOTF/Core/Gameplay/Attribute/AttributeModifier.cs
+++ b/Assets/KOTF/Core/Gameplay/Attribute/AttributeModifier.cs
@@ -14,7 +14,7 @@ namespace KOTF.Core.Gameplay.Attribute
     public class AnalogAttributeModifier : IAttributeModifier
     {
         public Guid Guid { get; } = new();
-        public IAttribute<float> Attribute { get; private set; }
+        public GatedAttribute<float> Attribute { get; private set; }
 
         [field: NonSerialized]
         public virtual float Threshold { get; set; }
@@ -28,14 +28,14 @@ namespace KOTF.Core.Gameplay.Attribute
             "The time interval between each update. [ms]\n Default value: 0.016f which corresponds to a rate of 60 Hz.")]
         public float Rate { get; set; } = 0.016f;
 
-        public void Initialize(IAttribute<float> attribute)
+        public void Initialize(GatedAttribute<float> attribute)
         {
             Attribute = attribute;
         }
 
-        public void Initialize(IAttribute<float> attribute, float threshold)
+        public void Initialize(GatedAttribute<float> attribute, float threshold)
         {
-            Initialize(attribute);
+            Attribute = attribute;
             Threshold = threshold;
         }
     }
@@ -44,23 +44,31 @@ namespace KOTF.Core.Gameplay.Attribute
     public class DiscreteAttributeModifier : IAttributeModifier
     {
         public Guid Guid { get; } = new();
-        public IAttribute<float> Attribute { get; private set; }
+        public GatedAttribute<float> Attribute { get; private set; }
 
         [field: SerializeField]
         public float Value { get; set; }
 
-        public void Initialize(IAttribute<float> attribute)
+        [field: NonSerialized]
+        public float Threshold { get; set; }
+
+        public void Initialize(GatedAttribute<float> attribute)
         {
             Attribute = attribute;
+        }
+
+        public void Initialize(GatedAttribute<float> attribute, float threshold)
+        {
+            Attribute = attribute;
+            Threshold = threshold;
         }
     }
 
     public interface IAttributeModifier
     {
         Guid Guid { get; }
-        IAttribute<float> Attribute { get; }
+        GatedAttribute<float> Attribute { get; }
         float Value { get; set; }
-
-        void Initialize(IAttribute<float> attribute);
+        float Threshold { get; set; }
     }
 }

--- a/Assets/KOTF/Core/Gameplay/Character/MainPlayerCharacter.cs
+++ b/Assets/KOTF/Core/Gameplay/Character/MainPlayerCharacter.cs
@@ -68,8 +68,8 @@ namespace KOTF.Core.Gameplay.Character
 
             _characterController = GetComponent<CharacterController>();
 
-            BaseStaminaEnhancer.Initialize(StaminaAttribute, StaminaAttribute.MaximumValue);
-            MovementSpeedEnhancer.Initialize(MovementSpeedAttribute, MovementSpeedAttribute.MaximumValue);
+            BaseStaminaEnhancer.Initialize(StaminaAttribute);
+            MovementSpeedEnhancer.Initialize(MovementSpeedAttribute);
             MovementSpeedDiminisher.Initialize(MovementSpeedAttribute);
             AttackingMovementSpeedDiminisher.Initialize(MovementSpeedAttribute);
 


### PR DESCRIPTION
…esults in inconsistent value clamping.

Whenever a threshold is 0.0f (not serialized), then that means we'll simply clamp to the attribute's min/max value automatically, instead of forcing a threshold initialization.